### PR TITLE
Add optional support for native Let's Encrypt

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ It:
 * Fetches the Concourse binary tarball from the official site.
 * Creates a wrapper script that captures options passed into the binary executable.
 * Installs necessary ssh key files, provided through variables.
+* (Optionally) enables Let's Encrypt using [Concourse' native support](https://concourse-ci.org/concourse-web.html#lets-encrypt) that was added in [5.3.0](https://github.com/concourse/concourse/releases/tag/v5.3.0)
 
 It does not:
 * Generate ssh key-pairs.
@@ -80,6 +81,7 @@ but exist for when control over related behaviour is needed. See examples for a 
 ### Web Variables
 
 * `concourse_web`: Optional. Set to "yes" to install the Concourse ATC.
+* `concourse_letsencrypt`: Optional. Set to "yes" to enable Concourse' native Let's Encrypt support.
 * `concourse_bind_ip`: Optional. The IP address on which to listen to web traffic.
 * `concourse_bind_port`: Optional. The port on which to listen for HTTP traffic.
 * `concourse_tls_bind_port`: Optional. The port on which to listen for HTTPS traffic.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,7 +14,7 @@ concourse_gid: "{{ concourse_uid }}"
 
 # Installation variables
 
-concourse_version: 5.0.1
+concourse_version: 5.4.0
 concourse_install_prefix_dir: /opt
 concourse_install_dir: "{{ concourse_install_prefix_dir }}/concourse"
 concourse_bin_dir: "{{ concourse_install_dir }}/bin"
@@ -22,7 +22,7 @@ concourse_binary_path: "{{ concourse_bin_dir }}/concourse"
 concourse_etc_dir: "{{ concourse_install_dir }}/etc"
 concourse_archive_name: concourse-{{ concourse_version }}-{{ concourse_archive_os }}-{{ concourse_archive_arch }}.tgz
 concourse_archive_url: https://github.com/concourse/concourse/releases/download/v{{ concourse_version }}/{{ concourse_archive_name }}
-concourse_archive_checksum: sha256:4d44d24a93d116a5f81c35de4c344aad4634156249b6860932fa256705ce38aa
+concourse_archive_checksum: sha256:ccc35f4ee5a9b9f5cba107040fe08815d0514d3dc52bc224af088271863f0f40
 concourse_archive_os: linux
 concourse_archive_arch: amd64
 concourse_archive_fetch_timeout: 30

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,6 +39,7 @@ concourse_service_start: yes
 # Web variables
 
 concourse_web: no
+concourse_letsencrypt: no
 #concourse_bind_ip:
 #concourse_bind_port: 8080
 #concourse_tls_bind_port: 443

--- a/templates/concourse-web.service.j2
+++ b/templates/concourse-web.service.j2
@@ -10,6 +10,10 @@ Restart=on-failure
 ExecStart={{ concourse_web_launcher_path }}
 ExecReload=/bin/kill -HUP $MAINPID
 KillSignal=SIGTERM
+{% if concourse_letsencrypt %}
+Environment=CONCOURSE_TLS_BIND_PORT=443
+Environment=CONCOURSE_ENABLE_LETS_ENCRYPT=true
+{% endif %}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Since [5.3.0](https://github.com/concourse/concourse/releases/tag/v5.3.0), Concourse supports Let's Encrypt natively.

This PR allows to optionally enable it on the web node. It defaults to "no".

Note that this PR requires [PR #3](https://github.com/troykinsella/ansible-concourse/pull/3) to be merged, because Let's Encrypt was added with 5.3.0.