### PR TITLE
Update default version of Concourse to 5.4.0

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,7 +14,7 @@ concourse_gid: "{{ concourse_uid }}"
 
 # Installation variables
 
-concourse_version: 5.0.1
+concourse_version: 5.4.0
 concourse_install_prefix_dir: /opt
 concourse_install_dir: "{{ concourse_install_prefix_dir }}/concourse"
 concourse_bin_dir: "{{ concourse_install_dir }}/bin"
@@ -22,7 +22,7 @@ concourse_binary_path: "{{ concourse_bin_dir }}/concourse"
 concourse_etc_dir: "{{ concourse_install_dir }}/etc"
 concourse_archive_name: concourse-{{ concourse_version }}-{{ concourse_archive_os }}-{{ concourse_archive_arch }}.tgz
 concourse_archive_url: https://github.com/concourse/concourse/releases/download/v{{ concourse_version }}/{{ concourse_archive_name }}
-concourse_archive_checksum: sha256:4d44d24a93d116a5f81c35de4c344aad4634156249b6860932fa256705ce38aa
+concourse_archive_checksum: sha256:ccc35f4ee5a9b9f5cba107040fe08815d0514d3dc52bc224af088271863f0f40
 concourse_archive_os: linux
 concourse_archive_arch: amd64
 concourse_archive_fetch_timeout: 30


### PR DESCRIPTION
Latest is greatest, and everything is actually fine. When I said [that Concourse had DNS issues](https://github.com/troykinsella/ansible-concourse/pull/3#issuecomment-517766274), I was wrong. I just failed to understand how the resolution actually works in Concourse. It turned our to be a config issue when running on Ubuntu, which was easily solved by adding the following Garden config to the worker:

```yaml
concourse_garden_config: |
  [server]
  dns-server = 8.8.8.8
  dns-server = 8.8.4.4
```

This patch will also be the prereq for native Let's Encrypt support, which is going to be another PR coming soon.