### PR TITLE
Allow support for environment vars for web and worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ but exist for when control over related behaviour is needed. See examples for a 
 * `concourse_auth_duration`: Optional. The length of time for which tokens are valid.
 * `concourse_resource_checking_interval`: Optional. Interval on which to check for new versions of resources. 
 * `concourse_web_options`: Optional. Other non-managed options to pass to `concourse`.
+* `concourse_web_env_vars`: Optional. A dictionary of environment variables to set when the web node runs
 
 #### Web PostgreSQL Variables
 
@@ -163,6 +164,7 @@ Unsupported. Do it yer dang self by supplying `concourse web` command options wi
 * `concourse_garden_config_path`: Optional.
   Normally, only `concourse_garden_config` needs to be defined.  
 * `concourse_worker_options`: Optional. Other non-managed options to pass to `concourse`.
+* `concourse_worker_env_vars`: Optional. A dictionary of environment variables to set when the worker node runs
 * `concourse_manage_work_volume`: Optional. Default: "no". Activate management of the work volume.
 * `concourse_work_volume_device`: Required when `concourse_manage_work_volume` is "yes". The device to mount as the work volume.
 * `concourse_work_volume_fs_type`: Optional. The filesystem type of the work volume. By default, this is calculated to be `btrfs` or `ext4` based on the value of `concourse_baggageclaim_driver`.
@@ -190,6 +192,8 @@ Unsupported. Do it yer dang self by supplying `concourse web` command options wi
         concourse_main_team_local_users:
         - admin
         concourse_external_url: http://concourse.example.com
+        concourse_web_env_vars:
+          CONCOURSE_SECRET_RETRY_ATTEMPTS: 5
 
     - hosts: workers
       roles:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -62,6 +62,7 @@ concourse_session_signing_key_path: "{{ concourse_etc_dir }}/session_signing_key
 #concourse_auth_duration:
 #concourse_resource_checking_interval:
 #concourse_web_options:
+concourse_web_env_vars: {}
 
 # Web PostgreSQL variables
 
@@ -110,6 +111,7 @@ concourse_tsa_worker_key_path: "{{ concourse_etc_dir }}/worker_key"
 #concourse_garden_config:
 concourse_garden_config_path: "{{ concourse_etc_dir }}/garden.conf"
 #concourse_worker_options:
+concourse_worker_env_vars: {}
 
 # Worker filesystem variables
 

--- a/templates/concourse-web.service.j2
+++ b/templates/concourse-web.service.j2
@@ -7,6 +7,9 @@ After=network-online.target
 
 [Service]
 Restart=on-failure
+{% for env_var_name, env_var_value in concourse_web_env_vars.items() %}
+Environment={{ env_var_name }}={{ env_var_value }}
+{% endfor %}
 ExecStart={{ concourse_web_launcher_path }}
 ExecReload=/bin/kill -HUP $MAINPID
 KillSignal=SIGTERM

--- a/templates/concourse-worker.service.j2
+++ b/templates/concourse-worker.service.j2
@@ -10,6 +10,9 @@ TasksMax=infinity
 LimitNOFILE=infinity
 LimitMEMLOCK=infinity
 Restart=on-failure
+{% for env_var_name, env_var_value in concourse_worker_env_vars.items() %}
+Environment={{ env_var_name }}={{ env_var_value }}
+{% endfor %}
 ExecStart={{ concourse_worker_launcher_path }}
 {% if concourse_worker_land_on_stop %}
 ExecStop={{ concourse_worker_land_path }}


### PR DESCRIPTION
Fixes #7 

Adds a new config option for the web nodes and worker nodes to define environment variables for them.

One thing to potentially discuss, any preference between these two approaches?
**Option 1**
```yml
- role: concourse
  concourse_web_env_vars:
    MY_ENV_VAR_1: "Here is the value"
    MY_ENV_VAR_2: "Another value"
```
**Option 2**
```yml
- role: concourse
  concourse_web_env_vars:
    - "MY_ENV_VAR_1=Here is the value"
    - "MY_ENV_VAR_2=Another value"
```