### PR TITLE
Add btrfs and fix gdn issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ but exist for when control over related behaviour is needed. See examples for a 
 * `concourse_authorized_worker_keys`: Required. Concatenated authorized worker keys.
 * `concourse_auth_duration`: Optional. The length of time for which tokens are valid.
 * `concourse_resource_checking_interval`: Optional. Interval on which to check for new versions of resources. 
+* `concourse_base_resource_type_defaults`: Optional. A hash of cluster-wide defaults for resource types.
+* `concourse_base_resource_type_defaults_file`: Optional. The path to the resource type defaults file.
 * `concourse_web_options`: Optional. Other non-managed options to pass to `concourse`.
 * `concourse_web_env`: Optional. A hash of environment variables made available to the `concourse web` process.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -62,6 +62,7 @@ concourse_session_signing_key_path: "{{ concourse_etc_dir }}/session_signing_key
 #concourse_authorized_worker_keys: []
 #concourse_auth_duration:
 #concourse_resource_checking_interval:
+concourse_base_resource_type_defaults_file: "{{ concourse_etc_dir }}/brt_defaults.yml"
 #concourse_web_options:
 concourse_web_env: {}
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -21,6 +21,12 @@
   when: concourse_web_service is defined and concourse_web and concourse_service_enabled and concourse_service_start
 
 - name: restart concourse worker
+  pause:
+    seconds: 10
+  notify:
+    - restart concourse worker after pause
+
+- name: restart concourse worker after pause
   service:
     name: concourse-worker
     state: restarted

--- a/tasks/web/configure.yml
+++ b/tasks/web/configure.yml
@@ -55,3 +55,15 @@
   when: concourse_tls_key is defined
   notify:
   - restart concourse web
+
+- name: copy resource type defaults
+  copy:
+    content: "{{ concourse_base_resource_type_defaults | to_yaml }}"
+    dest: "{{ concourse_base_resource_type_defaults_file }}"
+    owner: "{{ concourse_user }}"
+    group: "{{ concourse_group }}"
+    mode: "{{ concourse_etc_files_mode }}"
+  become: yes
+  when: concourse_base_resource_type_defaults is defined
+  notify:
+  - restart concourse web

--- a/tasks/worker/filesystem.yml
+++ b/tasks/worker/filesystem.yml
@@ -7,6 +7,13 @@
   become: yes
   when: concourse_baggageclaim_driver == 'btrfs'
 
+- name: Check btrfs-progs is present
+  package:
+     name: btrfs-progs
+     state: present
+  become: yes
+  when: concourse_baggageclaim_driver == 'btrfs'
+
 - name: probe overlay module
   modprobe:
     name: overlay

--- a/templates/concourse-web.j2
+++ b/templates/concourse-web.j2
@@ -101,6 +101,9 @@ exec {{ concourse_binary_path }} web \
 {% if concourse_resource_checking_interval is defined %}
   --resource-checking-interval "{{ concourse_resource_checking_interval }}" \
 {% endif %}
+{% if concourse_base_resource_type_defaults is defined %}
+  --base-resource-type-defaults "{{ concourse_base_resource_type_defaults_file }}" \
+{% endif %}
 {% if concourse_web_options is defined %}
   {{ concourse_web_options }}
 {% endif %}

--- a/test/playbook.yml
+++ b/test/playbook.yml
@@ -22,6 +22,10 @@
       password: "admin"
     concourse_main_team_local_users:
     - admin
+    concourse_base_resource_type_defaults:
+      registry-image:
+        registry_mirror:
+          host: https://cache.example.com
   - role: /role
     tags:
     - worker

--- a/test/spec/default/fixtures/brt_default.yml
+++ b/test/spec/default/fixtures/brt_default.yml
@@ -1,0 +1,3 @@
+registry-image:
+    registry_mirror:
+        host: https://cache.example.com

--- a/test/spec/default/installation_spec.rb
+++ b/test/spec/default/installation_spec.rb
@@ -61,6 +61,17 @@ describe file('/opt/concourse/etc/session_signing_key') do
   its(:content) { should eq fixture }
 end
 
+describe file('/opt/concourse/etc/brt_defaults.yml') do
+  it { should exist }
+  it { should be_file }
+  it { should be_owned_by 'concourse' }
+  it { should be_grouped_into 'concourse'}
+  it { should be_mode 400 }
+
+  fixture = File.read(File.join(Dir.pwd, "spec/default/fixtures/brt_default.yml")).strip + "\n"
+  its(:content) { should eq fixture }
+end
+
 # Worker
 
 describe file('/opt/concourse/work') do


### PR DESCRIPTION
This PR fixes a bug with gdn initialization and checks if btrfs-progs package is installed on the system when btrfs storage driver is selected. 

When concourse-worker starts it starts a gdn child process and the first time this process is run it creates a directory structure under /var/gdn. The father process (concourse-worker) doesn't wait until this inizialization is completed and then if we do something like "systemctl start concourse-worker && systemctl restart concourse-worker" the child process is killed and the directory structure remains in a half state. The next time that gdn child process runs, it detects that /var/gdn exists and doesn't overwrite it, then the process fails when it tries to run some program that should be inside /var/gdn but it's not.

To solve that, we wrote a pause task of 10 seconds before restarting the service to let the child process finish the initialization.