### PR TITLE
Install btrfs-progs package when btrfs driver is used

### DIFF
--- a/tasks/worker/filesystem.yml
+++ b/tasks/worker/filesystem.yml
@@ -7,6 +7,13 @@
   become: yes
   when: concourse_baggageclaim_driver == 'btrfs'
 
+- name: install btrfs-progs package
+  package:
+     name: btrfs-progs
+     state: present
+  become: yes
+  when: concourse_baggageclaim_driver == 'btrfs'
+
 - name: probe overlay module
   modprobe:
     name: overlay


### PR DESCRIPTION
Partially replaces https://github.com/troykinsella/ansible-concourse/pull/12, applying the changes mentioned there.