### PR TITLE
Add support for defining base resource type defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ but exist for when control over related behaviour is needed. See examples for a 
 * `concourse_authorized_worker_keys`: Required. Concatenated authorized worker keys.
 * `concourse_auth_duration`: Optional. The length of time for which tokens are valid.
 * `concourse_resource_checking_interval`: Optional. Interval on which to check for new versions of resources. 
+* `concourse_base_resource_type_defaults`: Optional. A hash of cluster-wide defaults for resource types.
+* `concourse_base_resource_type_defaults_file`: Optional. The path to the resource type defaults file.
 * `concourse_web_options`: Optional. Other non-managed options to pass to `concourse`.
 * `concourse_web_env`: Optional. A hash of environment variables made available to the `concourse web` process.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -62,6 +62,7 @@ concourse_session_signing_key_path: "{{ concourse_etc_dir }}/session_signing_key
 #concourse_authorized_worker_keys: []
 #concourse_auth_duration:
 #concourse_resource_checking_interval:
+concourse_base_resource_type_defaults_file: "{{ concourse_etc_dir }}/base_resource_type_defaults.yml"
 #concourse_web_options:
 concourse_web_env: {}
 

--- a/tasks/web/configure.yml
+++ b/tasks/web/configure.yml
@@ -55,3 +55,15 @@
   when: concourse_tls_key is defined
   notify:
   - restart concourse web
+
+- name: copy resource type defaults
+  copy:
+    content: "{{ concourse_base_resource_type_defaults | to_nice_yaml }}"
+    dest: "{{ concourse_base_resource_type_defaults_file }}"
+    owner: "{{ concourse_user }}"
+    group: "{{ concourse_group }}"
+    mode: "{{ concourse_etc_files_mode }}"
+  become: yes
+  when: concourse_base_resource_type_defaults is defined
+  notify:
+  - restart concourse web

--- a/templates/concourse-web.j2
+++ b/templates/concourse-web.j2
@@ -101,6 +101,9 @@ exec {{ concourse_binary_path }} web \
 {% if concourse_resource_checking_interval is defined %}
   --resource-checking-interval "{{ concourse_resource_checking_interval }}" \
 {% endif %}
+{% if concourse_base_resource_type_defaults is defined %}
+  --base-resource-type-defaults "{{ concourse_base_resource_type_defaults_file }}" \
+{% endif %}
 {% if concourse_web_options is defined %}
   {{ concourse_web_options }}
 {% endif %}

--- a/test/playbook.yml
+++ b/test/playbook.yml
@@ -22,6 +22,10 @@
       password: "admin"
     concourse_main_team_local_users:
     - admin
+    concourse_base_resource_type_defaults:
+      registry-image:
+        registry_mirror:
+          host: cache.example.com
   - role: /role
     tags:
     - worker

--- a/test/spec/default/fixtures/base_resource_type_defaults.yml
+++ b/test/spec/default/fixtures/base_resource_type_defaults.yml
@@ -1,0 +1,3 @@
+registry-image:
+    registry_mirror:
+        host: cache.example.com

--- a/test/spec/default/installation_spec.rb
+++ b/test/spec/default/installation_spec.rb
@@ -61,6 +61,17 @@ describe file('/opt/concourse/etc/session_signing_key') do
   its(:content) { should eq fixture }
 end
 
+describe file('/opt/concourse/etc/base_resource_type_defaults.yml') do
+  it { should exist }
+  it { should be_file }
+  it { should be_owned_by 'concourse' }
+  it { should be_grouped_into 'concourse'}
+  it { should be_mode 400 }
+
+  fixture = File.read(File.join(Dir.pwd, "spec/default/fixtures/base_resource_type_defaults.yml")).strip + "\n"
+  its(:content) { should eq fixture }
+end
+
 # Worker
 
 describe file('/opt/concourse/work') do


### PR DESCRIPTION
Introduced in Concourse v6.7.0, this makes it possible to specify
cluster-wide defaults for resource types, such as a registry-image
mirror.