### PR TITLE
Adds vault integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 ---
-service:
+services:
 - docker
 
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,23 @@
 FROM python:3
 
 RUN set -eux; \
-    export DEBIAN_FRONTEND=noninteractive; \
-    apt-get update; \
-    apt-get install -y \
-      git \
-      openssh-client \
-      ruby; \
-    pip install --no-cache-dir \
-      ansible; \
-    gem install serverspec;
+  export DEBIAN_FRONTEND=noninteractive; \
+  apt-get update; \
+  apt-get install -y \
+  git \
+  openssh-client \
+  ruby; \
+  pip install --no-cache-dir \
+  ansible; \
+  gem install serverspec;
 
 COPY . /role
 
 RUN set -eux; \
-    cd /role/test; \
-    ls -al /opt; \
-    cp /role/test/spec/default/fixtures/concourse.tar.gz /opt/concourse.tar.gz; \
-    ansible-playbook -i inventory --skip-tags no-test -t web playbook.yml; \
-    cp /role/test/spec/default/fixtures/concourse.tar.gz /opt/concourse.tar.gz; \
-    ansible-playbook -i inventory --skip-tags no-test -t worker playbook.yml; \
-    rake spec
+  cd /role/test; \
+  ls -al /opt; \
+  cp /role/test/spec/default/fixtures/concourse.tar.gz /opt/concourse.tar.gz; \
+  ansible-playbook -i inventory --skip-tags no-test -t web playbook.yml; \
+  cp /role/test/spec/default/fixtures/concourse.tar.gz /opt/concourse.tar.gz; \
+  ansible-playbook -i inventory --skip-tags no-test -t worker playbook.yml; \
+  rake spec

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ but exist for when control over related behaviour is needed. See examples for a 
 * `concourse_service_enabled`: Optional. Default: "yes". Manage a `systemd` service for a Concourse `web` and/or `worker` instance.
 * `concourse_service_start`: Optional. Default: "yes". Start the `systemd` service(s) for Concourse `web` and/or `worker`.
 * `concourse_log_level`: Optional. The minimum level of logs to see. [debug|info|error|fatal]
-* `concourse_env_file`: Optional. A file containing environment variables which is fed into the `EnvironmentFile` attribute of the 
+* `concourse_env_file`: Optional. A file containing environment variables which is fed into the `EnvironmentFile` attribute of the
   `systemd` service unit file. This is useful for configuration managed outside of the playbook. If
   the configuration should be managed by the playbook, `concourse_web_env` and/or `concourse_worker_env` is
   the better choice.
@@ -95,12 +95,14 @@ but exist for when control over related behaviour is needed. See examples for a 
 * `concourse_tls_bind_port`: Optional. The port on which to listen for HTTPS traffic.
 * `concourse_tls_certificate`: Optional. The content of the TLS certificate to use for HTTPS termination.
 * `concourse_tls_certificate_path`: Optional. The remote file path of the TLS certificate to use for HTTPS termination.
-  Normally, only `concourse_tls_certificate` needs to be defined.  
+  Normally, only `concourse_tls_certificate` needs to be defined.
 * `concourse_tls_key`: Optional. Optional. The content of the TLS key to use for HTTPS termination.
 * `concourse_tls_key_path`: Optional. The remote file path of the TLS key to use for HTTPS termination.
-  Normally, only `concourse_tls_key` needs to be defined. 
+  Normally, only `concourse_tls_key` needs to be defined.
 * `concourse_peer_address`: Optional. The URL at which this ATC can be reached from other ATCs in the cluster.
 * `concourse_external_url`: Optional. The URL at which any ATC can be reached from the outside.
+* `concourse_vault_url`: Optional. The URL at which the vault server can be reached, if using the vault credential manager.
+* `concourse_vault_client_token`: Optional. The vault periodic token. Required if vault_url is defined.
 * `concourse_web_launcher_path`: Optional. The path to the script that launches the Concourse web process.
 * `concourse_web_launcher_mode`: Optional. The file mode of the web launcher script.
 * `concourse_cli_artifacts_dir`: Optional. The value of the `--cli-artifacts-dir` option.
@@ -109,13 +111,13 @@ but exist for when control over related behaviour is needed. See examples for a 
 * `concourse_session_signing_key`: Required. The session signing key.
 * `concourse_session_signing_key_path`: Optional. The path to the session signing key file.
 * `concourse_encryption_key`: Optional. A 16 or 32 length key used to encrypt sensitive data before storing
-  it in the database 
-* `concourse_old_encryption_key`: Optional. An encryption key previously used. If provided without a new key, 
+  it in the database
+* `concourse_old_encryption_key`: Optional. An encryption key previously used. If provided without a new key,
   data is encrypted. If provided with a new key, data is re-encrypted.
 * `concourse_host_key`: Required. The host key.
 * `concourse_authorized_worker_keys`: Required. Concatenated authorized worker keys.
 * `concourse_auth_duration`: Optional. The length of time for which tokens are valid.
-* `concourse_resource_checking_interval`: Optional. Interval on which to check for new versions of resources. 
+* `concourse_resource_checking_interval`: Optional. Interval on which to check for new versions of resources.
 * `concourse_base_resource_type_defaults`: Optional. A hash of cluster-wide defaults for resource types.
 * `concourse_base_resource_type_defaults_file`: Optional. The path to the resource type defaults file.
 * `concourse_web_options`: Optional. Other non-managed options to pass to `concourse`.
@@ -126,7 +128,7 @@ but exist for when control over related behaviour is needed. See examples for a 
 * `concourse_postgres_host`: Optional. The Postgres host to connect to.
 * `concourse_postgres_port`: Optional. The Postgres port to connect to.
 * `concourse_postgres_socket`: Optional. The path to a Unix domain socket to connect to.
-* `concourse_postgres_user`: Optional. The Postgres user to sign in as. 
+* `concourse_postgres_user`: Optional. The Postgres user to sign in as.
 * `concourse_postgres_password`: Optional. The Postgres user's password.
 * `concourse_postgres_ssl_mode`: Optional. Whether or not to use SSL with the Postgres connection.
 * `concourse_postgres_ca_cert`: Optional. The Postgres CA cert file location.
@@ -137,7 +139,7 @@ but exist for when control over related behaviour is needed. See examples for a 
 
 #### Web Local Authentication Variables
 
-* `concourse_local_users`: Optional. A list of concourse user credentials that are added as local users. 
+* `concourse_local_users`: Optional. A list of concourse user credentials that are added as local users.
   Entries are objects having `name` and `password` fields (see example). Passwords can be plain text or bcrypted.
 * `concourse_main_team_local_users`: Optional. List of whitelisted local concourse users (of the supplied local user list).
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,7 +14,7 @@ concourse_gid: "{{ concourse_uid }}"
 
 # Installation variables
 
-concourse_version: 7.1.0
+concourse_version: 7.2.0
 concourse_install_prefix_dir: /opt
 concourse_install_dir: "{{ concourse_install_prefix_dir }}/concourse"
 concourse_bin_dir: "{{ concourse_install_dir }}/bin"
@@ -22,7 +22,7 @@ concourse_binary_path: "{{ concourse_bin_dir }}/concourse"
 concourse_etc_dir: "{{ concourse_install_dir }}/etc"
 concourse_archive_name: "concourse-{{ concourse_version }}-{{ concourse_archive_os }}-{{ concourse_archive_arch }}.tgz"
 concourse_archive_url: "https://github.com/concourse/concourse/releases/download/v{{ concourse_version }}/{{ concourse_archive_name }}"
-concourse_archive_checksum: "sha1:cd63e3660aaa7705f83bb432088affa23eb0d3b6"
+concourse_archive_checksum: "sha1:54a1650e98cc6b1ed78790a00affbe7ccf445b6c"
 concourse_archive_os: linux
 concourse_archive_arch: amd64
 concourse_archive_fetch_timeout: 30

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -56,6 +56,8 @@ concourse_authorized_worker_keys_path: "{{ concourse_etc_dir }}/authorized_worke
 concourse_host_key_path: "{{ concourse_etc_dir }}/host_key"
 #concourse_session_signing_key:
 concourse_session_signing_key_path: "{{ concourse_etc_dir }}/session_signing_key"
+#concourse_vault_url:
+#concourse_vault_client_token:
 #concourse_encryption_key:
 #concourse_old_encryption_key:
 #concourse_host_key:

--- a/templates/concourse-web.j2
+++ b/templates/concourse-web.j2
@@ -32,6 +32,12 @@ exec {{ concourse_binary_path }} web \
 {% if concourse_external_url %}
   --external-url "{{ concourse_external_url }}" \
 {% endif %}
+{% if concourse_vault_url %}
+  --vault-url "{{ concourse_vault_url }}" \
+{% endif %}
+{% if concourse_vault_client_token %}
+  --vault-client-token "{{ concourse_vault_client_token }}" \
+{% endif %}
 {% if concourse_encryption_key is defined %}
   --encryption-key "{{ concourse_encryption_key }}" \
 {% endif %}

--- a/test/playbook.yml
+++ b/test/playbook.yml
@@ -13,6 +13,8 @@
     concourse_authorized_worker_keys:
     - "{{ lookup('file', 'spec/default/fixtures/worker_key.pub') }}"
     concourse_external_url: "http://localhost:8080/"
+    concourse_vault_url: "http://localhost:8200"
+    concourse_vault_client_token: "vault-client-token"
     concourse_postgres_database: atc
     concourse_postgres_user: concourse
     concourse_postgres_password: concourse

--- a/test/spec/default/concourse_web_configuration_spec.rb
+++ b/test/spec/default/concourse_web_configuration_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+describe file('/opt/concourse/bin/concourse-web') do
+  its(:content) { should contain '--vault-url' }
+  its(:content) { should contain '--vault-client-token' }
+end


### PR DESCRIPTION
I use vault as a [credential manager ](https://concourse-ci.org/vault-credential-manager.html) for my internal installation, and I needed to install it through ansible. I added support for this in my fork, so submitting this PR in case you would like to see it upstream. 

Also adds an additional test/spec/default/concourse_web_configuration_spec.rb that will check the contents of the concourse-web configuration.

Currently only supports using periodic tokens. Approle auth backend or cert auth still missing.

