### PR TITLE
Optional keys in favour of bootstrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,14 @@ but exist for when control over related behaviour is needed. See examples for a 
 * `concourse_web`: Optional. Set to "yes" to install the Concourse ATC.
 * `concourse_bind_ip`: Optional. The IP address on which to listen to web traffic.
 * `concourse_bind_port`: Optional. The port on which to listen for HTTP traffic.
+* `concourse_host_key`: Optional. The host key.
+* `concourse_authorized_worker_keys`: Optional. Concatenated authorized worker keys.
+* `concourse_session_signing_key`: Optional. The session signing key.
+
+  **Note**: if the keys are not provided, then it is expected that the corresponding paths (i.e. `concourse_(host|session_signing|authorized_worker)_key_path`) are given for Concourse configuration, and the files with proper values are provisioned during the bootstrap.
+* `concourse_authorized_worker_keys_path`: Optional. The path to the authorized worker keys file.
+* `concourse_host_key_path`: Optional. The path to the host key file.
+* `concourse_session_signing_key_path`: Optional. The path to the session signing key file.
 * `concourse_tls_bind_port`: Optional. The port on which to listen for HTTPS traffic.
 * `concourse_tls_certificate`: Optional. The content of the TLS certificate to use for HTTPS termination.
 * `concourse_tls_certificate_path`: Optional. The remote file path of the TLS certificate to use for HTTPS termination.
@@ -104,16 +112,10 @@ but exist for when control over related behaviour is needed. See examples for a 
 * `concourse_web_launcher_path`: Optional. The path to the script that launches the Concourse web process.
 * `concourse_web_launcher_mode`: Optional. The file mode of the web launcher script.
 * `concourse_cli_artifacts_dir`: Optional. The value of the `--cli-artifacts-dir` option.
-* `concourse_authorized_worker_keys_path`: Optional. The path to the authorized worker keys file.
-* `concourse_host_key_path`: Optional. The path to the host key file.
-* `concourse_session_signing_key`: Required. The session signing key.
-* `concourse_session_signing_key_path`: Optional. The path to the session signing key file.
 * `concourse_encryption_key`: Optional. A 16 or 32 length key used to encrypt sensitive data before storing
   it in the database
 * `concourse_old_encryption_key`: Optional. An encryption key previously used. If provided without a new key,
   data is encrypted. If provided with a new key, data is re-encrypted.
-* `concourse_host_key`: Required. The host key.
-* `concourse_authorized_worker_keys`: Required. Concatenated authorized worker keys.
 * `concourse_auth_duration`: Optional. The length of time for which tokens are valid.
 * `concourse_resource_checking_interval`: Optional. Interval on which to check for new versions of resources.
 * `concourse_base_resource_type_defaults`: Optional. A hash of cluster-wide defaults for resource types.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ to the concourse binary at launch time. Run `concourse web -h` or `concourse wor
 Note: The vast majority of variables have sensible defaults and normally need not be defined,
 but exist for when control over related behaviour is needed. See examples for a minimal configuration set.
 
+**IMPORTANT**: do NOT use Ansible variables with sensitive keys, passwords and secrets in production, i.e. `concourse_encryption_key`, `concourse_github_client_secret`, `concourse_postgres_password`. As they will be leaked and exposed both in the logs and in the process' command string. Instead set the corresponding environment variables in `concourse_web_env`, i.e. `CONCOURSE_ENCRYPTION_KEY`, `CONCOURSE_GITHUB_CLIENT_SECRET`, `CONCOURSE_POSTGRES_PASSWORD`, etc.
+
 ### Maintenance Variables
 
 * `concourse_force_restart`: Optional. Default: "no". Triggers a restart of the web and/or worker services regardless as to whether or not configuration has changed.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ but exist for when control over related behaviour is needed. See examples for a 
 * `concourse_service_enabled`: Optional. Default: "yes". Manage a `systemd` service for a Concourse `web` and/or `worker` instance.
 * `concourse_service_start`: Optional. Default: "yes". Start the `systemd` service(s) for Concourse `web` and/or `worker`.
 * `concourse_log_level`: Optional. The minimum level of logs to see. [debug|info|error|fatal]
-* `concourse_env_file`: Optional. A file containing environment variables which is fed into the `EnvironmentFile` attribute of the 
+* `concourse_env_file`: Optional. A file containing environment variables which is fed into the `EnvironmentFile` attribute of the
   `systemd` service unit file. This is useful for configuration managed outside of the playbook. If
   the configuration should be managed by the playbook, `concourse_web_env` and/or `concourse_worker_env` is
   the better choice.
@@ -95,10 +95,10 @@ but exist for when control over related behaviour is needed. See examples for a 
 * `concourse_tls_bind_port`: Optional. The port on which to listen for HTTPS traffic.
 * `concourse_tls_certificate`: Optional. The content of the TLS certificate to use for HTTPS termination.
 * `concourse_tls_certificate_path`: Optional. The remote file path of the TLS certificate to use for HTTPS termination.
-  Normally, only `concourse_tls_certificate` needs to be defined.  
+  Normally, only `concourse_tls_certificate` needs to be defined.
 * `concourse_tls_key`: Optional. Optional. The content of the TLS key to use for HTTPS termination.
 * `concourse_tls_key_path`: Optional. The remote file path of the TLS key to use for HTTPS termination.
-  Normally, only `concourse_tls_key` needs to be defined. 
+  Normally, only `concourse_tls_key` needs to be defined.
 * `concourse_peer_address`: Optional. The URL at which this ATC can be reached from other ATCs in the cluster.
 * `concourse_external_url`: Optional. The URL at which any ATC can be reached from the outside.
 * `concourse_web_launcher_path`: Optional. The path to the script that launches the Concourse web process.
@@ -109,13 +109,13 @@ but exist for when control over related behaviour is needed. See examples for a 
 * `concourse_session_signing_key`: Required. The session signing key.
 * `concourse_session_signing_key_path`: Optional. The path to the session signing key file.
 * `concourse_encryption_key`: Optional. A 16 or 32 length key used to encrypt sensitive data before storing
-  it in the database 
-* `concourse_old_encryption_key`: Optional. An encryption key previously used. If provided without a new key, 
+  it in the database
+* `concourse_old_encryption_key`: Optional. An encryption key previously used. If provided without a new key,
   data is encrypted. If provided with a new key, data is re-encrypted.
 * `concourse_host_key`: Required. The host key.
 * `concourse_authorized_worker_keys`: Required. Concatenated authorized worker keys.
 * `concourse_auth_duration`: Optional. The length of time for which tokens are valid.
-* `concourse_resource_checking_interval`: Optional. Interval on which to check for new versions of resources. 
+* `concourse_resource_checking_interval`: Optional. Interval on which to check for new versions of resources.
 * `concourse_base_resource_type_defaults`: Optional. A hash of cluster-wide defaults for resource types.
 * `concourse_base_resource_type_defaults_file`: Optional. The path to the resource type defaults file.
 * `concourse_web_options`: Optional. Other non-managed options to pass to `concourse`.
@@ -126,7 +126,7 @@ but exist for when control over related behaviour is needed. See examples for a 
 * `concourse_postgres_host`: Optional. The Postgres host to connect to.
 * `concourse_postgres_port`: Optional. The Postgres port to connect to.
 * `concourse_postgres_socket`: Optional. The path to a Unix domain socket to connect to.
-* `concourse_postgres_user`: Optional. The Postgres user to sign in as. 
+* `concourse_postgres_user`: Optional. The Postgres user to sign in as.
 * `concourse_postgres_password`: Optional. The Postgres user's password.
 * `concourse_postgres_ssl_mode`: Optional. Whether or not to use SSL with the Postgres connection.
 * `concourse_postgres_ca_cert`: Optional. The Postgres CA cert file location.
@@ -137,7 +137,7 @@ but exist for when control over related behaviour is needed. See examples for a 
 
 #### Web Local Authentication Variables
 
-* `concourse_local_users`: Optional. A list of concourse user credentials that are added as local users. 
+* `concourse_local_users`: Optional. A list of concourse user credentials that are added as local users.
   Entries are objects having `name` and `password` fields (see example). Passwords can be plain text or bcrypted.
 * `concourse_main_team_local_users`: Optional. List of whitelisted local concourse users (of the supplied local user list).
 
@@ -166,8 +166,10 @@ Unsupported. Do it yer dang self by supplying `concourse web` command options wi
 * `concourse_tsa_public_key_path`: Optional. The path to the tsa public key file.
 * `concourse_tsa_worker_key_path`: Optional. The path to the worker private key file.
 * `concourse_tsa_host`: Required. The value of the `--tsa-host` option.
-* `concourse_tsa_public_key`: Required. The tsa public key.
-* `concourse_tsa_worker_key`: Required. The tsa worker private key.
+* `concourse_tsa_public_key`: Optional. The tsa public key.
+* `concourse_tsa_worker_key`: Optional. The tsa worker private key.
+
+  **Note**: if a key is not provided, then it is expected that the corresponding path (i.e. `concourse_tsa_(public|worker)_key_path`) is given for Concourse configuration, and the file with a proper value is provisioned during the bootstrap.
 * `concourse_worker_tag`: Optional. The value of the `--tag` option.
 * `concourse_baggageclaim_driver`: Optional. The driver to use for managing volumes.
 * `concourse_worker_options`: Optional. Other non-managed options to pass to `concourse`.
@@ -183,6 +185,7 @@ Unsupported. Do it yer dang self by supplying `concourse web` command options wi
 
 ## Example Playbook
 
+```yaml
     - hosts: atc
       roles:
       - role: troykinsella.concourse
@@ -211,6 +214,7 @@ Unsupported. Do it yer dang self by supplying `concourse web` command options wi
           CONCOURSE_GARDEN_NETWORK_POOL: 10.254.0.0/16
           CONCOURSE_GARDEN_MAX_CONTAINERS: 512
           CONCOURSE_GARDEN_DOCKER_REGISTRY: https://docker.my-private-registry.org
+```
 
 ## Testing
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,4 @@
 ---
-- name: main - print extra info
-  ansible.builtin.debug:
-    msg:
-      - "concourse_baggageclaim_driver: {{ concourse_baggageclaim_driver }}"
 
 - include: user.yml
   when: concourse_manage_user
@@ -14,5 +10,5 @@
 - shell: /bin/true
   when: concourse_force_restart
   notify:
-  - restart concourse web
-  - restart concourse worker
+    - restart concourse web
+    - restart concourse worker

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: main - print extra info
+  ansible.builtin.debug:
+    msg:
+      - "concourse_baggageclaim_driver: {{ concourse_baggageclaim_driver }}"
 
 - include: user.yml
   when: concourse_manage_user

--- a/tasks/web/configure.yml
+++ b/tasks/web/configure.yml
@@ -1,5 +1,5 @@
 ---
-- name: copy host key
+- name: configure/web - copy host key
   copy:
     content: "{{ concourse_host_key }}"
     dest: "{{ concourse_host_key_path }}"
@@ -8,9 +8,10 @@
     mode: "{{ concourse_etc_files_mode }}"
   become: yes
   notify:
-  - restart concourse web
+    - restart concourse web
+  when: concourse_host_key is defined and concourse_host_key|length
 
-- name: copy session signing key
+- name: configure/web - copy session signing key
   copy:
     content: "{{ concourse_session_signing_key }}"
     dest: "{{ concourse_session_signing_key_path }}"
@@ -19,9 +20,10 @@
     mode: "{{ concourse_etc_files_mode }}"
   become: yes
   notify:
-  - restart concourse web
+    - restart concourse web
+  when: concourse_session_signing_key is defined and concourse_session_signing_key|length
 
-- name: copy authorized worker keys
+- name: configure/web - copy authorized worker keys
   template:
     src: authorized_worker_keys.j2
     dest: "{{ concourse_authorized_worker_keys_path }}"
@@ -30,9 +32,10 @@
     mode: "{{ concourse_etc_files_mode }}"
   become: yes
   notify:
-  - restart concourse web
+    - restart concourse web
+  when: concourse_authorized_worker_keys is defined and concourse_authorized_worker_keys|length
 
-- name: tls certificate | concourse
+- name: configure/web - tls certificate | concourse
   copy:
     content: "{{ concourse_tls_certificate }}"
     dest: "{{ concourse_tls_certificate_path }}"
@@ -42,9 +45,9 @@
   become: yes
   when: concourse_tls_certificate is defined
   notify:
-  - restart concourse web
+    - restart concourse web
 
-- name: tls key | concourse
+- name: configure/web - tls key | concourse
   copy:
     content: "{{ concourse_tls_key }}"
     dest: "{{ concourse_tls_key_path }}"
@@ -54,9 +57,9 @@
   become: yes
   when: concourse_tls_key is defined
   notify:
-  - restart concourse web
+    - restart concourse web
 
-- name: copy resource type defaults
+- name: configure/web - copy resource type defaults
   copy:
     content: "{{ concourse_base_resource_type_defaults | to_nice_yaml }}"
     dest: "{{ concourse_base_resource_type_defaults_file }}"
@@ -66,4 +69,4 @@
   become: yes
   when: concourse_base_resource_type_defaults is defined
   notify:
-  - restart concourse web
+    - restart concourse web

--- a/tasks/worker/configure.yml
+++ b/tasks/worker/configure.yml
@@ -1,5 +1,5 @@
 ---
-- name: copy tsa public key
+- name: configure/worker - copy tsa public key
   copy:
     content: "{{ concourse_tsa_public_key }}"
     dest: "{{ concourse_tsa_public_key_path }}"
@@ -8,9 +8,10 @@
     mode: "{{ concourse_etc_files_mode }}"
   become: yes
   notify:
-  - restart concourse worker
+    - restart concourse worker
+  when: concourse_tsa_public_key is defined and concourse_tsa_public_key|length
 
-- name: copy worker key
+- name: configure/worker - copy worker key
   copy:
     content: "{{ concourse_tsa_worker_key }}"
     dest: "{{ concourse_tsa_worker_key_path }}"
@@ -19,4 +20,5 @@
     mode: "{{ concourse_etc_files_mode }}"
   become: yes
   notify:
-  - restart concourse worker
+    - restart concourse worker
+  when: concourse_tsa_worker_key is defined and concourse_tsa_worker_key|length

--- a/tasks/worker/filesystem.yml
+++ b/tasks/worker/filesystem.yml
@@ -1,4 +1,9 @@
 ---
+- name: worker/filesystem - print extra info
+  ansible.builtin.debug:
+    msg:
+      - "concourse_baggageclaim_driver: {{ concourse_baggageclaim_driver }}"
+
 - name: probe btrfs module
   modprobe:
     name: btrfs

--- a/tasks/worker/filesystem.yml
+++ b/tasks/worker/filesystem.yml
@@ -1,25 +1,24 @@
 ---
-
 - name: probe btrfs module
   modprobe:
     name: btrfs
     state: present
   become: yes
-  when: concourse_baggageclaim_driver == 'btrfs'
+  when: concourse_baggageclaim_driver == "btrfs"
 
 - name: install btrfs-progs package
   package:
-     name: btrfs-progs
-     state: present
+    name: btrfs-progs
+    state: present
   become: yes
-  when: concourse_baggageclaim_driver == 'btrfs'
+  when: concourse_baggageclaim_driver == "btrfs"
 
 - name: probe overlay module
   modprobe:
     name: overlay
     state: present
   become: yes
-  when: concourse_baggageclaim_driver == 'overlay'
+  when: concourse_baggageclaim_driver == "overlay"
 
 - name: unmount work volume
   mount:

--- a/tasks/worker/filesystem.yml
+++ b/tasks/worker/filesystem.yml
@@ -1,9 +1,4 @@
 ---
-- name: worker/filesystem - print extra info
-  ansible.builtin.debug:
-    msg:
-      - "concourse_baggageclaim_driver: {{ concourse_baggageclaim_driver }}"
-
 - name: probe btrfs module
   modprobe:
     name: btrfs
@@ -30,6 +25,7 @@
     path: "{{ concourse_work_volume_mount_path }}"
     state: unmounted
   become: yes
+  when: concourse_manage_work_volume
 
 - name: create work volume filesystem
   filesystem:
@@ -38,6 +34,7 @@
     force: "{{ concourse_work_volume_fs_force_create }}"
     resizefs: "{{ concourse_work_volume_fs_resize }}"
   become: yes
+  when: concourse_manage_work_volume
 
 - name: mount work volume
   mount:
@@ -47,3 +44,4 @@
     opts: "{{ concourse_work_volume_mount_opts }}"
     state: mounted
   become: yes
+  when: concourse_manage_work_volume

--- a/tasks/worker/install.yml
+++ b/tasks/worker/install.yml
@@ -9,7 +9,6 @@
   become: yes
 
 - include: filesystem.yml
-  when: concourse_manage_work_volume
 
 - name: create worker launch script
   template:
@@ -21,7 +20,7 @@
     force: yes
   become: yes
   notify:
-  - restart concourse worker
+    - restart concourse worker
 
 - name: create worker land script
   template:
@@ -52,7 +51,7 @@
   become: yes
   register: concourse_worker_service
   notify:
-  - restart concourse worker
-  - systemd daemon reload
+    - restart concourse worker
+    - systemd daemon reload
   tags:
-  - no-test
+    - no-test


### PR DESCRIPTION
- made the required keys optional, in favour of providing corresponding `key_path` variables during instance bootstrapping.
Reasoning: when building an image, whether Docker, AWS AMI or anything else, it's better not include any sensitive information but rather include it upon container/instance bootstrapping. 

- minor reformatting

- added a warning about not using variables invoking command line arguments with sensitive secrets, i.e. keys, passwords, etc. Use corresponding environment variables.
Reasoning: leakage and exposure to `procps` and system logs. 

```sh
$ ps axf  | grep concou
 365430 ?        Ssl    0:01 /opt/concourse/bin/concourse web ... --encryption-key <unencrypted key here>  .. --postgres-password <plain-text pass> ... --github-client-secret <plain-text token> ...
```

and here is an example of exported logs
![image](https://user-images.githubusercontent.com/16941995/139595140-671dc17f-cd8a-4dec-9402-f171d12755c4.png)
